### PR TITLE
Add {future} to `Suggests` in `DESCRIPTION`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Imports:
     progressr,
     R6
 Suggests:
+    future,
     ggplot2,
     knitr,
     rmarkdown,


### PR DESCRIPTION
To fix the `R CMD check --as-cran` warning on tests using it but not declared as a dependency.