### PR TITLE
Install XQuartz on macOS for SVG plotting support

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,6 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # To support plotting with SVG device under macOS
+      - if: runner.os == 'macOS'
+        run: brew install --cask xquartz
+
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2


### PR DESCRIPTION
Following the advice from r-lib/actions REAMDE common questions section.